### PR TITLE
update runtime to 14.29.30133

### DIFF
--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, Anaconda Inc - Anaconda Recipes
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,7 +13,7 @@ cl_version:
 #     Note the 14.15.26706 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 tools_version:
 #  - 14.25.28610
-  - 14.27.29016
+  - 14.29.30133
 runtime_version:
-  - 14.27.29016
+  - 14.29.30133
 # we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,10 +4,10 @@ VER:
   - 16
 # the VS update version.  This is the middle digit in the version reported in the VS help->about UI.  It is perhaps a more readily referenceable number.
 update_version:
-  - 5
+  - 11
 # this is the version number reported by cl.exe
 cl_version:
-  - 19.27.29111
+  - 19.29.30154
 # this version follows the version number reported for the vcruntim140.dll file.
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Redist\MSVC\14.15.26706\x64\Microsoft.VC141.CRT
 #     Note the 14.15.26706 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,8 @@ outputs:
         - {{ pin_subpackage('vs' ~ runtime_year ~ '_runtime', max_pin=None) }}
     about:
       home: https://github.com/conda/conda/wiki/VC-features
-      license: Modified BSD License (3-clause)
+      license: BSD-3-Clause
+      license_file: {{ RECIPE_DIR }}/LICENSE
       license_family: BSD
       summary: A meta-package to impose mutual exclusivity among software built with different VS versions
       description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ package:
   version: 1.0.0
 
 build:
-  skip: True  [not win]
-  number: 2
+  skip: True # [not win]
+  number: 3
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
vs2015_runtime 14.29.30133
vs2019_win-64  19.29.30154

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-4632
- https://anaconda.atlassian.net/browse/PKG-4633

### Explanation of changes:
- repackage vs2015_runtime based on the latest installed on our builders, to address vulnerabilities.
