### PR TITLE
Bugfix: Don't set target platform (incorrectly) in compiler scripts

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -66,11 +66,9 @@ if errorlevel 1 (
 )
 
 IF "@cross_compiler_target_platform@" == "win-64" (
-  set "target_platform=amd64"
   set "CMAKE_GEN=Visual Studio @VER@ @YEAR@ Win64"
   set "BITS=64"
 ) else (
-  set "target_platform=x86"
   set "CMAKE_GEN=Visual Studio @VER@ @YEAR@"
   set "BITS=32"
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,6 @@ outputs:
   - name: vc
     version: {{ vcver }}
     build:
-      number: 1
       track_features:
         - vc{{ vcver.split(".")[0] }}
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 3
+  number: 4
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
**Destination channel:**  defaults

### Explanation of changes:

- uncovered while building ffmpeg via autotools_clang_conda
- Removed build number: skip-existing breaks conda-package-handling step, see [this issue](https://github.com/conda/conda-build/issues/4856) for more info, it looks like it's not being addressed so have removed the build number here to work around
