### PR TITLE
set sdk restriction to <10.0.2261.0

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -56,7 +56,12 @@ call :GetWin10SdkDir
 :: dir /ON here is sorting the list of folders, such that we use the latest one that we have
 for /F %%i in ('dir /ON /B "%WindowsSdkDir%\include"') DO (
   if NOT "%%~i" == "wdf" (
-    SET WindowsSDKVer=%%~i
+    :: SDKs including and after 10.0.22621.0 do not offer optimal compatibility with VS2019.
+    for /f "tokens=3 delims=." %%a in ("%%~i") do (
+        if %%a LSS 22621 (
+            SET WindowsSDKVer=%%~i
+        )
+    )
   )
 )
 if errorlevel 1 (

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 4
+  number: 5
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
There are build issues using vs2019 with the latest SDK (which is meant for vs2022). 
This PR updates the activation script to not pick the latest SDK.

The kind of issues when building with vs2019 are:
`libucrt.lib(checkcfg.obj) : error LNK2001: unresolved external symbol _guard_check_icall_$fo$    
`

https://anaconda.atlassian.net/browse/PKG-5614