### PR TITLE
set INCLUDE, LIB and CMAKE_PREFIX_PATH in reg env

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -46,9 +46,15 @@ set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\"
 )
 
 IF NOT "%CONDA_BUILD%" == "" (
+  :: building packages
   set "INCLUDE=%LIBRARY_INC%;%INCLUDE%"
   set "LIB=%LIBRARY_LIB%;%LIB%"
   set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
+) else (
+  :: normal environment
+  set "INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%"
+  set "LIB=%CONDA_PREFIX%\Library\lib;%LIB%"
+  set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library;%CMAKE_PREFIX_PATH%"
 )
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 5
+  number: 6
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
## Changes
- Fixes https://github.com/AnacondaRecipes/pytorch-feedstock/issues/55
- Sets `INCLUDE`, `LIB` and `CMAKE_PREFIX_PATH` to the correct paths. Useful for feedstocks that use this compiler during runtime or in tests. 

Related: https://github.com/AnacondaRecipes/vs2022-feedstock/pull/4
